### PR TITLE
Fix history hooks imports

### DIFF
--- a/src/components/Layout/Footer/Footer.js
+++ b/src/components/Layout/Footer/Footer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from "./Footer.module.css";
 import { Button } from 'primereact/button';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { BsInstagram } from "react-icons/bs";
 import { BiRadio } from "react-icons/bi";
 

--- a/src/components/Layout/Header/AdminHeader/AdminHeader.js
+++ b/src/components/Layout/Header/AdminHeader/AdminHeader.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styles from "./AdminHeader.module.css";
 import logo from '../../../../assets/img/logo-01.png';
 import { Button } from 'primereact/button';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import NavUser from './nav/NavUser';
 import { confirmDialog } from 'primereact/confirmdialog';
 

--- a/src/components/Layout/Header/AdminHeader/nav/NavUser.js
+++ b/src/components/Layout/Header/AdminHeader/nav/NavUser.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Sidebar } from 'primereact/sidebar';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import styles from './styles.module.css';
 import { confirmDialog } from 'primereact/confirmdialog';
 

--- a/src/components/Layout/Header/PrivateHeader/PrivateHeader.js
+++ b/src/components/Layout/Header/PrivateHeader/PrivateHeader.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { Button } from 'primereact/button';
 import { confirmDialog } from 'primereact/confirmdialog';

--- a/src/components/Layout/Header/PrivateHeader/nav/NavUser.js
+++ b/src/components/Layout/Header/PrivateHeader/nav/NavUser.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Sidebar } from 'primereact/sidebar';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import styles from './navUser.module.scss';
 import { confirmDialog } from 'primereact/confirmdialog';
 

--- a/src/pages/Admin/Admin/Admin.js
+++ b/src/pages/Admin/Admin/Admin.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import styles from './styles.module.css';
 import logo from '../../../assets/img/logo-01.png';
 

--- a/src/pages/Admin/AfiliadosNuevos/AfiliadosNuevos.js
+++ b/src/pages/Admin/AfiliadosNuevos/AfiliadosNuevos.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/Asesoramiento/Asesoramiento.js
+++ b/src/pages/Admin/Asesoramiento/Asesoramiento.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/Cuotas/Cuotas.js
+++ b/src/pages/Admin/Cuotas/Cuotas.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/Cursos/Cursos.js
+++ b/src/pages/Admin/Cursos/Cursos.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/Enlaces/Enlaces.js
+++ b/src/pages/Admin/Enlaces/Enlaces.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/Novedades/Novedades.js
+++ b/src/pages/Admin/Novedades/Novedades.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/NuevaCuota/NuevaCuota.js
+++ b/src/pages/Admin/NuevaCuota/NuevaCuota.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useForm } from '../../../hooks/useForm';
 import { clearStatus, nuevaCuota, uploadCuota } from '../../../redux/reducers/cuotas/actions';
 import styles from './styles.module.css';

--- a/src/pages/Admin/NuevaNovedad/NuevaNovedad.js
+++ b/src/pages/Admin/NuevaNovedad/NuevaNovedad.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import { useForm } from '../../../hooks/useForm';
 import global from '../../../assets/styles/global.module.css';

--- a/src/pages/Admin/NuevoAfiliado/NuevoAfiliado.js
+++ b/src/pages/Admin/NuevoAfiliado/NuevoAfiliado.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useForm } from '../../../hooks/useForm';
 import { nuevoAfiliado, updateUser } from '../../../redux/reducers/afiliados/actions';
 import styles from './styles.module.css';

--- a/src/pages/Admin/NuevoAsesoramiento/NuevoAsesoramiento.js
+++ b/src/pages/Admin/NuevoAsesoramiento/NuevoAsesoramiento.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import { useForm } from '../../../hooks/useForm';
 import global from '../../../assets/styles/global.module.css';

--- a/src/pages/Admin/NuevoCurso/NuevoCurso.js
+++ b/src/pages/Admin/NuevoCurso/NuevoCurso.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import { useForm } from '../../../hooks/useForm';
 import { clearStatus, nuevoCurso, uploadCurso, uploadImg } from '../../../redux/reducers/cursos/actions';

--- a/src/pages/Admin/NuevoEnlace/NuevoEnlace.js
+++ b/src/pages/Admin/NuevoEnlace/NuevoEnlace.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useForm } from '../../../hooks/useForm';
 import { clearStatus, nuevoEnlace, uploadEnlace } from '../../../redux/reducers/enlaces/actions';
 import styles from './styles.module.css';

--- a/src/pages/Admin/Transacciones/Transacciones.js
+++ b/src/pages/Admin/Transacciones/Transacciones.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/TransaccionesUsuario/TransaccionesUsuario.js
+++ b/src/pages/Admin/TransaccionesUsuario/TransaccionesUsuario.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';

--- a/src/pages/Admin/Usuarios/Usuarios.js
+++ b/src/pages/Admin/Usuarios/Usuarios.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useHistory } from 'react-router'
+import { useHistory } from 'react-router-dom'
 import styles from './styles.module.css';
 import { Button } from 'primereact/button';
 import { InputText } from 'primereact/inputtext';

--- a/src/pages/Capacitaciones/Cursos/Cursos.js
+++ b/src/pages/Capacitaciones/Cursos/Cursos.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import styles from './styles.module.css';
-import { useHistory, useParams } from 'react-router';
+import { useHistory, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from "react-redux";
 import CursosSkeleton from "../../../components/Cursos/CursosSkeleton";
 import CursosCard from "../../../components/Cards/CursosCard";

--- a/src/pages/CasaDelDocente/CasaDelDocente.js
+++ b/src/pages/CasaDelDocente/CasaDelDocente.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styles from './styles.module.css';
 import { Button } from 'primereact/button';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 
 const CasaDelDocente = () => {
 

--- a/src/pages/Predio/Predio.js
+++ b/src/pages/Predio/Predio.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styles from './styles.module.css';
 import { Button } from 'primereact/button';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 
 const Predio = () => {
 

--- a/src/pages/Turismo/Turismo.js
+++ b/src/pages/Turismo/Turismo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './styles.module.css';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { Button } from 'primereact/button';
 
 const Turismo = () => {


### PR DESCRIPTION
## Summary
- use `react-router-dom` instead of `react-router` for history and params hooks

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dea7b9354832886fa6e1bbb729010